### PR TITLE
JDK compatibility to 1.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,22 @@ repositories {
     jcenter()
 }
 
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
+
+plugins.withType(JavaPlugin) {
+
+    project.tasks.withType(JavaCompile) { task ->
+        task.sourceCompatibility = project.sourceCompatibility
+        task.targetCompatibility = project.targetCompatibility
+    }
+
+    project.tasks.withType(GroovyCompile) { task ->
+        task.sourceCompatibility = project.sourceCompatibility
+        task.targetCompatibility = project.targetCompatibility
+    }
+}
+
 dependencies {
     codenarc('org.codenarc:CodeNarc:1.0') {
         exclude module: 'GMetrics'


### PR DESCRIPTION
Excerpt From: Schalk Cronjé. “Idiomatic Gradle Plugins.” 
>Just setting the sourceCompatibility and targetCompatibility properties in the script to 1.6 will not be enough. The Java and Groovy plugins have to be told to recognise these properties.

See: https://github.com/grails/grails-core/issues/10884